### PR TITLE
Prevent ScrollDiffMargin from affecting the scroll bar behavior

### DIFF
--- a/GitDiffMargin/View/ScrollDiffMarginControl.xaml
+++ b/GitDiffMargin/View/ScrollDiffMarginControl.xaml
@@ -51,7 +51,7 @@
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
                     <Grid>
-                        <Control Name="diffControl">
+                        <Control Name="diffControl" IsHitTestVisible="False">
                             <Control.Style>
                                 <Style TargetType="{x:Type Control}">
                                     <Style.Triggers>


### PR DESCRIPTION
Simple change of setting `IsHitTestVisible="False"`.

Could be reverted in the future if special behavior of some sort was provided for these controls, but for now they don't seem to do anything.
