### PR TITLE
Auto show popup after Next Change or Previous Change command

### DIFF
--- a/GitDiffMargin/View/EditorDiffMarginControl.xaml
+++ b/GitDiffMargin/View/EditorDiffMarginControl.xaml
@@ -118,8 +118,9 @@
             <Popup AllowsTransparency="True"
                    HorizontalOffset="8"
                    IsOpen="{Binding ShowPopup, Mode=TwoWay}"
-                   Placement="MousePoint"
+                   Placement="Custom"
                    PlacementTarget="{Binding ElementName=diffControl}"
+                   CustomPopupPlacementCallback="HandleCustomPopupPlacement"
                    StaysOpen="False">
               <Border Background="Transparent">
                 <StackPanel Orientation="Vertical">

--- a/GitDiffMargin/View/EditorDiffMarginControl.xaml.cs
+++ b/GitDiffMargin/View/EditorDiffMarginControl.xaml.cs
@@ -1,5 +1,8 @@
 ﻿namespace GitDiffMargin.View
 {
+    using System.Windows;
+    using System.Windows.Controls.Primitives;
+
     /// <summary>
     ///   Interaction logic for EditorDiffMarginControl.xaml
     /// </summary>
@@ -8,6 +11,15 @@
         public EditorDiffMarginControl()
         {
             InitializeComponent();
+        }
+
+        private CustomPopupPlacement[] HandleCustomPopupPlacement(Size popupSize, Size targetSize, Point offset)
+        {
+            // TODO: Change vertical placement to be relative to mouse position IFF the mouse is vertically within the
+            // target diff glyph.
+            CustomPopupPlacement verticalPlacement = new CustomPopupPlacement(offset, PopupPrimaryAxis.Vertical);
+            CustomPopupPlacement horizontalPlacement = new CustomPopupPlacement(offset, PopupPrimaryAxis.Horizontal);
+            return new[] { verticalPlacement, horizontalPlacement };
         }
     }
 }

--- a/GitDiffMargin/ViewModel/EditorDiffMarginViewModel.cs
+++ b/GitDiffMargin/ViewModel/EditorDiffMarginViewModel.cs
@@ -64,6 +64,7 @@ namespace GitDiffMargin.ViewModel
             MarginCore.MoveToChange(diffViewModel.LineNumber);    
 
             ((EditorDiffViewModel)currentDiffViewModel).ShowPopup = false;
+            ((EditorDiffViewModel)diffViewModel).ShowPopUpCommand.Execute(this);
         }
 
         protected override void HandleHunksChanged(object sender, HunksChangedEventArgs e)


### PR DESCRIPTION
Update the **Jump to Next Change** and **Jump to Previous Change** implementations to automatically show the popup for the target change. This feature required changing the location where the popup appears to be relative to the actual diff instead of relative to the cursor. The behavior would be improved if it were further updated to use the custom placement _only_ in response to the **Jump to Next Change** or **Jump to Previous Change** commands, and use the mouse placement when the diff is actually clicked in the margin.
