### PR TITLE
Make sure the text editor is focused after a rollback

### DIFF
--- a/GitDiffMargin/Core/IMarginCore.cs
+++ b/GitDiffMargin/Core/IMarginCore.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Media;
 using GitDiffMargin.Git;
 using Microsoft.VisualStudio.Text;
+using Microsoft.VisualStudio.Text.Editor;
 
 namespace GitDiffMargin.Core
 {
@@ -13,6 +14,7 @@ namespace GitDiffMargin.Core
 
         event EventHandler<HunksChangedEventArgs> HunksChanged;
 
+        IWpfTextView TextView { get; }
         IGitCommands GitCommands { get; }
         FontFamily FontFamily { get; }
         FontStretch FontStretch { get; }

--- a/GitDiffMargin/Core/MarginCore.cs
+++ b/GitDiffMargin/Core/MarginCore.cs
@@ -51,6 +51,14 @@ namespace GitDiffMargin.Core
             UpdateBrushes();
         }
 
+        public IWpfTextView TextView
+        {
+            get
+            {
+                return _textView;
+            }
+        }
+
         public IGitCommands GitCommands
         {
             get

--- a/GitDiffMargin/ViewModel/EditorDiffViewModel.cs
+++ b/GitDiffMargin/ViewModel/EditorDiffViewModel.cs
@@ -209,6 +209,9 @@ namespace GitDiffMargin.ViewModel
             _reverted = true;
             ShowPopup = false;
             IsVisible = false;
+
+            // Make sure the view is focused afterwards
+            MarginCore.TextView.VisualElement.Focus();
         }
 
         private void ShowPopUp()


### PR DESCRIPTION
Note: This pull request conflicts with #52, but they can be merged in either order. After the first of these two is merged, I'll update the other pull request to correct the merge conflict.
