### PR TITLE
Use IVsDifferenceService when available

### DIFF
--- a/GitDiffMargin/GitDiffMargin.csproj
+++ b/GitDiffMargin/GitDiffMargin.csproj
@@ -133,6 +133,12 @@
       <Private>False</Private>
       <HintPath>..\packages\VSSDK.Shell.Interop.10.10.0.2\lib\net20\Microsoft.VisualStudio.Shell.Interop.10.0.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <Private>False</Private>
+      <HintPath>..\packages\VSSDK.Shell.Interop.11.11.0.2\lib\net20\Microsoft.VisualStudio.Shell.Interop.11.0.dll</HintPath>
+      <Aliases>vs11</Aliases>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
       <HintPath>..\packages\VSSDK.Shell.Interop.8.8.0.2\lib\net20\Microsoft.VisualStudio.Shell.Interop.8.0.dll</HintPath>

--- a/GitDiffMargin/packages.config
+++ b/GitDiffMargin/packages.config
@@ -8,6 +8,7 @@
   <package id="VSSDK.Editor.10" version="10.0.2" targetFramework="net40" />
   <package id="VSSDK.IDE" version="7.0.2" targetFramework="net40" />
   <package id="VSSDK.IDE.10" version="10.0.2" targetFramework="net40" />
+  <package id="VSSDK.IDE.11" version="11.0.2" targetFramework="net40" />
   <package id="VSSDK.IDE.8" version="8.0.2" targetFramework="net40" />
   <package id="VSSDK.IDE.9" version="9.0.2" targetFramework="net40" />
   <package id="VSSDK.OLE.Interop" version="7.0.2" targetFramework="net40" />
@@ -15,6 +16,7 @@
   <package id="VSSDK.Shell.Immutable.10" version="10.0.2" targetFramework="net40" />
   <package id="VSSDK.Shell.Interop" version="7.0.2" targetFramework="net40" />
   <package id="VSSDK.Shell.Interop.10" version="10.0.2" targetFramework="net40" />
+  <package id="VSSDK.Shell.Interop.11" version="11.0.2" targetFramework="net40" />
   <package id="VSSDK.Shell.Interop.8" version="8.0.2" targetFramework="net40" />
   <package id="VSSDK.Shell.Interop.9" version="9.0.2" targetFramework="net40" />
   <package id="VSSDK.Text.10" version="10.0.2" targetFramework="net40" />


### PR DESCRIPTION
Use `IVsDifferenceService` when available. This fixes #27 even though no option is created for the command in the UI; since this is a Visual Studio extension it's reasonable to assume the default behavior should feel like Visual Studio (external diffs can always be opened in other ways). Extreme case was taken to not affect Visual Studio 2010 compatibility now or in the future.
1. The `vs11` alias is assigned to the interop referenced assembly from Visual Studio 2012, so it's impossible to accidentally use types introduced by this assembly.
2. The **Embed Interop Types** property is true for just this assembly, so the types are available in Visual Studio 2010.
3. The code handles cases where `IVsDifferenceService` is not available (specifically Visual Studio 2010).
