### PR TITLE
Fix fast up-to-date check

### DIFF
--- a/GitDiffMargin/GitDiffMargin.csproj
+++ b/GitDiffMargin/GitDiffMargin.csproj
@@ -239,11 +239,11 @@
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\GitDiffMargin-Preview.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\GitDiffMargin-Thumb.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="..\LICENSE.md">
@@ -259,7 +259,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\Git-Logo-2Color.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\Rollback.png" />
@@ -267,7 +267,7 @@
     <Content Include="Resources\NextArrow.png" />
     <Content Include="Resources\CopyOldText.png" />
     <Content Include="Resources\Git-Icon-1788C.ico">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\PreviousArrow.png" />


### PR DESCRIPTION
When any item in the project has a 'CopyToOutputDirectory' value of 'Always', the
fast up-to-date check always fails. This commit switches these items to
'PreserveNewest', allowing builds to be skipped when they are already up to date.