### PR TITLE
Support 'diffMarginBase' from '.git/config' as from branch

### DIFF
--- a/GitDiffMargin/Git/GitCommands.cs
+++ b/GitDiffMargin/Git/GitCommands.cs
@@ -59,7 +59,22 @@ namespace GitDiffMargin.Git
                     yield break;
                 }
 
-                if (retrieveStatus == FileStatus.Unaltered
+                // Determine 'from' tree.
+                var currentBranch = repo.Head.FriendlyName;
+                var baseCommitEntry = repo.Config.Get<string>(string.Format("branch.{0}.diffmarginbase", currentBranch));
+                Commit from = null;
+                if (baseCommitEntry != null)
+                {
+                    var baseCommit = repo.Lookup<Commit>(baseCommitEntry.Value);
+                    if (baseCommit != null)
+                    {
+                        // Found a merge base to diff from.
+                        from = baseCommit;
+                    }
+                }
+
+                if (from == null
+                    && retrieveStatus == FileStatus.Unaltered
                     && !textDocument.IsDirty
                     && Path.GetFullPath(filename) == originalPath)
                 {
@@ -99,7 +114,7 @@ namespace GitDiffMargin.Git
                     {
                         suppressRollback = false;
 
-                        Commit from = repo.Head.Tip;
+                        from = from ?? repo.Head.Tip;
                         TreeEntry fromEntry = from[relativeFilepath];
                         if (fromEntry == null)
                         {


### PR DESCRIPTION
This change adds a mechanism for advanced users to diff against something other than `HEAD` by including a `diffMarginBase` setting in `.git/config` associated with the current branch that specifies the branch that the diff should be relative to. This can be used, for example, for pull requests to show the same diffs in GitDiffMargin that would be shown by github for the branch associated with the PR.

For example:

```
[branch "master"]
    diffMarginBase = upstream-master
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/laurentkempe/gitdiffmargin/155)
<!-- Reviewable:end -->
