### PR TITLE
Center when moving to next/previous change

### DIFF
--- a/GitDiffMargin/Core/MarginCore.cs
+++ b/GitDiffMargin/Core/MarginCore.cs
@@ -199,7 +199,8 @@ namespace GitDiffMargin.Core
 
             _textView.VisualElement.Focus();
             _textView.Caret.MoveTo(diffLine.Start);
-            _textView.Caret.EnsureVisible();
+            _textView.ViewScroller.EnsureSpanVisible(diffLine.ExtentIncludingLineBreak,
+                EnsureSpanVisibleOptions.AlwaysCenter);
         }
 
         private void CheckBeginInvokeOnUi(Action action)


### PR DESCRIPTION
Currently GitDiffMargin uses `EnsureCaretVisible` to move to the next/previous change. If the next change is off-screen, this causes the first line of the change to appear at the bottom of the screen. Since the idea is to go across "no-man's-land" to get to the next diff, it would be much more helpful if the first line of the next diff were displayed in the center of the window.