### PR TITLE
Light up "modern command handling" in Visual Studio 2017 version 15.6+

### DIFF
--- a/GitDiffMargin.Commands/CommandHandlerTextViewCreationListener.cs
+++ b/GitDiffMargin.Commands/CommandHandlerTextViewCreationListener.cs
@@ -1,0 +1,37 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using System.ComponentModel.Composition;
+    using Microsoft.VisualStudio.Editor;
+    using Microsoft.VisualStudio.Shell;
+    using Microsoft.VisualStudio.Text.Editor;
+    using Microsoft.VisualStudio.TextManager.Interop;
+    using Microsoft.VisualStudio.Utilities;
+
+    [Export(typeof(IVsTextViewCreationListener))]
+    [ContentType("text")]
+    [TextViewRole(PredefinedTextViewRoles.Editable)]
+    internal class CommandHandlerTextViewCreationListener : IVsTextViewCreationListener
+    {
+        private readonly SVsServiceProvider _serviceProvider;
+        private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
+
+        [ImportingConstructor]
+        public CommandHandlerTextViewCreationListener(SVsServiceProvider serviceProvider, IVsEditorAdaptersFactoryService editorAdaptersFactoryService)
+        {
+            _serviceProvider = serviceProvider;
+            _editorAdaptersFactoryService = editorAdaptersFactoryService;
+        }
+
+        public void VsTextViewCreated(IVsTextView textViewAdapter)
+        {
+            ITextView textView = _editorAdaptersFactoryService.GetWpfTextView(textViewAdapter);
+            if (textView == null)
+                return;
+
+            // The new command handling approach does not require that the command filter be enabled. The command
+            // implementations interact directly with the handler via its IOleCommandTarget interface.
+            GitDiffMarginCommandHandler filter = new GitDiffMarginCommandHandler(textViewAdapter, _editorAdaptersFactoryService, textView);
+            textView.Properties.AddProperty(typeof(GitDiffMarginCommandHandler), filter);
+        }
+    }
+}

--- a/GitDiffMargin.Commands/CopyOldTextCommandArgs.cs
+++ b/GitDiffMargin.Commands/CopyOldTextCommandArgs.cs
@@ -1,0 +1,14 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using Microsoft.VisualStudio.Text;
+    using Microsoft.VisualStudio.Text.Editor;
+    using Microsoft.VisualStudio.Text.Editor.Commanding;
+
+    internal class CopyOldTextCommandArgs : EditorCommandArgs
+    {
+        public CopyOldTextCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/GitDiffMargin.Commands/CopyOldTextCommandHandler.cs
+++ b/GitDiffMargin.Commands/CopyOldTextCommandHandler.cs
@@ -1,0 +1,19 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using System.ComponentModel.Composition;
+    using Microsoft.VisualStudio.Commanding;
+    using Microsoft.VisualStudio.Utilities;
+
+    [Export(typeof(ICommandHandler))]
+    [ContentType("text")]
+    [Name(nameof(CopyOldTextCommandHandler))]
+    internal class CopyOldTextCommandHandler : GitDiffMarginCommandHandler<CopyOldTextCommandArgs>
+    {
+        public CopyOldTextCommandHandler()
+            : base(GitDiffMarginCommand.CopyOldText)
+        {
+        }
+
+        public override string DisplayName => "Copy Old Text";
+    }
+}

--- a/GitDiffMargin.Commands/GitDiffMargin.Commands.csproj
+++ b/GitDiffMargin.Commands/GitDiffMargin.Commands.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{AFEE8D6F-0358-4628-8CAC-D10668C95057}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GitDiffMargin.Commands</RootNamespace>
+    <AssemblyName>GitDiffMargin.Commands</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Editor" Version="15.6.27740" />
+    <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" Version="15.6.27413" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.6.56" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="StreamJsonRpc" Version="1.3.23" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CommandHandlerTextViewCreationListener.cs" />
+    <Compile Include="CopyOldTextCommandArgs.cs" />
+    <Compile Include="CopyOldTextCommandHandler.cs" />
+    <Compile Include="GitDiffMarginCommandBinding.cs" />
+    <Compile Include="GitDiffMarginCommandHandler`1.cs" />
+    <Compile Include="NextChangeCommandArgs.cs" />
+    <Compile Include="NextChangeCommandHandler.cs" />
+    <Compile Include="PreviousChangeCommandArgs.cs" />
+    <Compile Include="PreviousChangeCommandHandler.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RollbackChangeCommandArgs.cs" />
+    <Compile Include="RollbackChangeCommandHandler.cs" />
+    <Compile Include="ShimCommandHandler.cs" />
+    <Compile Include="ShowDiffCommandArgs.cs" />
+    <Compile Include="ShowDiffCommandHandler.cs" />
+    <Compile Include="ShowPopupCommandArgs.cs" />
+    <Compile Include="ShowPopupCommandHandler.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GitDiffMargin\GitDiffMargin.csproj">
+      <Project>{233b6f13-7687-4823-870b-a8f44b79d4f0}</Project>
+      <Name>GitDiffMargin</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/GitDiffMargin.Commands/GitDiffMarginCommandBinding.cs
+++ b/GitDiffMargin.Commands/GitDiffMarginCommandBinding.cs
@@ -1,0 +1,32 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using System.ComponentModel.Composition;
+    using Microsoft.VisualStudio.Editor.Commanding;
+
+    internal class GitDiffMarginCommandBinding
+    {
+#pragma warning disable CS0649 // Field 'fieldName' is never assigned to, and will always have its default value null
+
+        [Export]
+        [CommandBinding(GitDiffMarginCommandHandler.GitDiffMarginCommandSet, (uint)GitDiffMarginCommand.PreviousChange, typeof(PreviousChangeCommandArgs))]
+        internal CommandBindingDefinition PreviousChangeCommandBinding;
+
+        [Export]
+        [CommandBinding(GitDiffMarginCommandHandler.GitDiffMarginCommandSet, (uint)GitDiffMarginCommand.NextChange, typeof(NextChangeCommandArgs))]
+        internal CommandBindingDefinition NextChangeCommandBinding;
+
+        [Export]
+        [CommandBinding(GitDiffMarginCommandHandler.GitDiffMarginCommandSet, (uint)GitDiffMarginCommand.RollbackChange, typeof(RollbackChangeCommandArgs))]
+        internal CommandBindingDefinition RollbackChangeCommandBinding;
+
+        [Export]
+        [CommandBinding(GitDiffMarginCommandHandler.GitDiffMarginCommandSet, (uint)GitDiffMarginCommand.CopyOldText, typeof(CopyOldTextCommandArgs))]
+        internal CommandBindingDefinition CopyOldTextCommandBinding;
+
+        [Export]
+        [CommandBinding(GitDiffMarginCommandHandler.GitDiffMarginCommandSet, (uint)GitDiffMarginCommand.ShowPopup, typeof(ShowPopupCommandArgs))]
+        internal CommandBindingDefinition ShowPopupCommandBinding;
+
+#pragma warning restore CS0649 // Field 'fieldName' is never assigned to, and will always have its default value null
+    }
+}

--- a/GitDiffMargin.Commands/GitDiffMarginCommandHandler`1.cs
+++ b/GitDiffMargin.Commands/GitDiffMarginCommandHandler`1.cs
@@ -1,0 +1,18 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using System;
+    using Microsoft.VisualStudio.OLE.Interop;
+    using Microsoft.VisualStudio.Text.Editor.Commanding;
+
+    internal abstract class GitDiffMarginCommandHandler<T> : ShimCommandHandler<T>
+        where T : EditorCommandArgs
+    {
+        protected GitDiffMarginCommandHandler(GitDiffMarginCommand commandId)
+            : base(new Guid(GitDiffMarginCommandHandler.GitDiffMarginCommandSet), (uint)commandId)
+        {
+        }
+
+        protected override IOleCommandTarget GetCommandTarget(T args)
+            => args.TextView.Properties.GetProperty<GitDiffMarginCommandHandler>(typeof(GitDiffMarginCommandHandler));
+    }
+}

--- a/GitDiffMargin.Commands/NextChangeCommandArgs.cs
+++ b/GitDiffMargin.Commands/NextChangeCommandArgs.cs
@@ -1,0 +1,14 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using Microsoft.VisualStudio.Text;
+    using Microsoft.VisualStudio.Text.Editor;
+    using Microsoft.VisualStudio.Text.Editor.Commanding;
+
+    internal class NextChangeCommandArgs : EditorCommandArgs
+    {
+        public NextChangeCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/GitDiffMargin.Commands/NextChangeCommandHandler.cs
+++ b/GitDiffMargin.Commands/NextChangeCommandHandler.cs
@@ -1,0 +1,19 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using System.ComponentModel.Composition;
+    using Microsoft.VisualStudio.Commanding;
+    using Microsoft.VisualStudio.Utilities;
+
+    [Export(typeof(ICommandHandler))]
+    [ContentType("text")]
+    [Name(nameof(NextChangeCommandHandler))]
+    internal class NextChangeCommandHandler : GitDiffMarginCommandHandler<NextChangeCommandArgs>
+    {
+        public NextChangeCommandHandler()
+            : base(GitDiffMarginCommand.NextChange)
+        {
+        }
+
+        public override string DisplayName => "Next Change";
+    }
+}

--- a/GitDiffMargin.Commands/PreviousChangeCommandArgs.cs
+++ b/GitDiffMargin.Commands/PreviousChangeCommandArgs.cs
@@ -1,0 +1,14 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using Microsoft.VisualStudio.Text;
+    using Microsoft.VisualStudio.Text.Editor;
+    using Microsoft.VisualStudio.Text.Editor.Commanding;
+
+    internal class PreviousChangeCommandArgs : EditorCommandArgs
+    {
+        public PreviousChangeCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/GitDiffMargin.Commands/PreviousChangeCommandHandler.cs
+++ b/GitDiffMargin.Commands/PreviousChangeCommandHandler.cs
@@ -1,0 +1,19 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using System.ComponentModel.Composition;
+    using Microsoft.VisualStudio.Commanding;
+    using Microsoft.VisualStudio.Utilities;
+
+    [Export(typeof(ICommandHandler))]
+    [ContentType("text")]
+    [Name(nameof(PreviousChangeCommandHandler))]
+    internal class PreviousChangeCommandHandler : GitDiffMarginCommandHandler<PreviousChangeCommandArgs>
+    {
+        public PreviousChangeCommandHandler()
+            : base(GitDiffMarginCommand.PreviousChange)
+        {
+        }
+
+        public override string DisplayName => "Previous Change";
+    }
+}

--- a/GitDiffMargin.Commands/Properties/AssemblyInfo.cs
+++ b/GitDiffMargin.Commands/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GitDiffMargin.Commands")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GitDiffMargin.Commands")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("afee8d6f-0358-4628-8cac-d10668c95057")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GitDiffMargin.Commands/RollbackChangeCommandArgs.cs
+++ b/GitDiffMargin.Commands/RollbackChangeCommandArgs.cs
@@ -1,0 +1,14 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using Microsoft.VisualStudio.Text;
+    using Microsoft.VisualStudio.Text.Editor;
+    using Microsoft.VisualStudio.Text.Editor.Commanding;
+
+    internal class RollbackChangeCommandArgs : EditorCommandArgs
+    {
+        public RollbackChangeCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/GitDiffMargin.Commands/RollbackChangeCommandHandler.cs
+++ b/GitDiffMargin.Commands/RollbackChangeCommandHandler.cs
@@ -1,0 +1,19 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using System.ComponentModel.Composition;
+    using Microsoft.VisualStudio.Commanding;
+    using Microsoft.VisualStudio.Utilities;
+
+    [Export(typeof(ICommandHandler))]
+    [ContentType("text")]
+    [Name(nameof(RollbackChangeCommandHandler))]
+    internal class RollbackChangeCommandHandler : GitDiffMarginCommandHandler<RollbackChangeCommandArgs>
+    {
+        public RollbackChangeCommandHandler()
+            : base(GitDiffMarginCommand.RollbackChange)
+        {
+        }
+
+        public override string DisplayName => "Rollback Change";
+    }
+}

--- a/GitDiffMargin.Commands/ShimCommandHandler.cs
+++ b/GitDiffMargin.Commands/ShimCommandHandler.cs
@@ -1,0 +1,52 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using System;
+    using Microsoft.VisualStudio;
+    using Microsoft.VisualStudio.Commanding;
+    using Microsoft.VisualStudio.Shell;
+    using IOleCommandTarget = Microsoft.VisualStudio.OLE.Interop.IOleCommandTarget;
+    using OLECMD = Microsoft.VisualStudio.OLE.Interop.OLECMD;
+    using OLECMDEXECOPT = Microsoft.VisualStudio.OLE.Interop.OLECMDEXECOPT;
+    using OLECMDF = Microsoft.VisualStudio.OLE.Interop.OLECMDF;
+
+    internal abstract class ShimCommandHandler<T> : ICommandHandler<T>
+        where T : CommandArgs
+    {
+        private readonly Guid _commandSet;
+        private readonly uint _commandId;
+
+        protected ShimCommandHandler(Guid commandSet, uint commandId)
+        {
+            _commandSet = commandSet;
+            _commandId = commandId;
+        }
+
+        public abstract string DisplayName
+        {
+            get;
+        }
+
+        public virtual CommandState GetCommandState(T args)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            OLECMD[] command = { new OLECMD { cmdID = _commandId } };
+            ErrorHandler.ThrowOnFailure(GetCommandTarget(args).QueryStatus(_commandSet, 1, command, IntPtr.Zero));
+            if ((command[0].cmdf & (uint)OLECMDF.OLECMDF_SUPPORTED) == 0)
+                return CommandState.Unspecified;
+            else if ((command[0].cmdf & (uint)OLECMDF.OLECMDF_ENABLED) == 0)
+                return CommandState.Unavailable;
+            else
+                return CommandState.Available;
+        }
+
+        public virtual bool ExecuteCommand(T args, CommandExecutionContext executionContext)
+        {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
+            return ErrorHandler.Succeeded(GetCommandTarget(args).Exec(_commandSet, _commandId, (uint)OLECMDEXECOPT.OLECMDEXECOPT_DODEFAULT, IntPtr.Zero, IntPtr.Zero));
+        }
+
+        protected abstract IOleCommandTarget GetCommandTarget(T args);
+    }
+}

--- a/GitDiffMargin.Commands/ShowDiffCommandArgs.cs
+++ b/GitDiffMargin.Commands/ShowDiffCommandArgs.cs
@@ -1,0 +1,14 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using Microsoft.VisualStudio.Text;
+    using Microsoft.VisualStudio.Text.Editor;
+    using Microsoft.VisualStudio.Text.Editor.Commanding;
+
+    internal class ShowDiffCommandArgs : EditorCommandArgs
+    {
+        public ShowDiffCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/GitDiffMargin.Commands/ShowDiffCommandHandler.cs
+++ b/GitDiffMargin.Commands/ShowDiffCommandHandler.cs
@@ -1,0 +1,19 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using System.ComponentModel.Composition;
+    using Microsoft.VisualStudio.Commanding;
+    using Microsoft.VisualStudio.Utilities;
+
+    [Export(typeof(ICommandHandler))]
+    [ContentType("text")]
+    [Name(nameof(ShowDiffCommandHandler))]
+    internal class ShowDiffCommandHandler : GitDiffMarginCommandHandler<ShowDiffCommandArgs>
+    {
+        public ShowDiffCommandHandler()
+            : base(GitDiffMarginCommand.ShowDiff)
+        {
+        }
+
+        public override string DisplayName => "Show Diff";
+    }
+}

--- a/GitDiffMargin.Commands/ShowPopupCommandArgs.cs
+++ b/GitDiffMargin.Commands/ShowPopupCommandArgs.cs
@@ -1,0 +1,14 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using Microsoft.VisualStudio.Text;
+    using Microsoft.VisualStudio.Text.Editor;
+    using Microsoft.VisualStudio.Text.Editor.Commanding;
+
+    internal class ShowPopupCommandArgs : EditorCommandArgs
+    {
+        public ShowPopupCommandArgs(ITextView textView, ITextBuffer subjectBuffer)
+            : base(textView, subjectBuffer)
+        {
+        }
+    }
+}

--- a/GitDiffMargin.Commands/ShowPopupCommandHandler.cs
+++ b/GitDiffMargin.Commands/ShowPopupCommandHandler.cs
@@ -1,0 +1,19 @@
+﻿namespace GitDiffMargin.Commands
+{
+    using System.ComponentModel.Composition;
+    using Microsoft.VisualStudio.Commanding;
+    using Microsoft.VisualStudio.Utilities;
+
+    [Export(typeof(ICommandHandler))]
+    [ContentType("text")]
+    [Name(nameof(ShowPopupCommandHandler))]
+    internal class ShowPopupCommandHandler : GitDiffMarginCommandHandler<ShowPopupCommandArgs>
+    {
+        public ShowPopupCommandHandler()
+            : base(GitDiffMarginCommand.ShowPopup)
+        {
+        }
+
+        public override string DisplayName => "Show Popup";
+    }
+}

--- a/GitDiffMargin.Extension/GitDiffMargin.Extension.csproj
+++ b/GitDiffMargin.Extension/GitDiffMargin.Extension.csproj
@@ -52,6 +52,14 @@
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.5.72" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GitDiffMargin.Commands\GitDiffMargin.Commands.csproj">
+      <Project>{afee8d6f-0358-4628-8cac-d10668c95057}</Project>
+      <Name>GitDiffMargin.Commands</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\GitDiffMargin.LegacyCommands\GitDiffMargin.LegacyCommands.csproj">
+      <Project>{359ba5c3-6964-4fa4-941f-fb97e250c521}</Project>
+      <Name>GitDiffMargin.LegacyCommands</Name>
+    </ProjectReference>
     <ProjectReference Include="..\GitDiffMargin\GitDiffMargin.csproj">
       <Project>{233b6f13-7687-4823-870b-a8f44b79d4f0}</Project>
       <Name>GitDiffMargin</Name>

--- a/GitDiffMargin.Extension/GitDiffMargin.Extension.csproj
+++ b/GitDiffMargin.Extension/GitDiffMargin.Extension.csproj
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{E4701F35-8030-418E-8E8C-6AE72E229138}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GitDiffMargin.Extension</RootNamespace>
+    <AssemblyName>GitDiffMargin.Extension</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
+    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <TargetVsixContainerName>GitDiffMargin.vsix</TargetVsixContainerName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <!-- Common debugging support -->
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
+    <StartArguments>/rootSuffix Exp</StartArguments>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
+    <!-- This property disables extension deployment for command line builds; required for AppVeyor -->
+    <DeployExtension>False</DeployExtension>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.5.72" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GitDiffMargin\GitDiffMargin.csproj">
+      <Project>{233b6f13-7687-4823-870b-a8f44b79d4f0}</Project>
+      <Name>GitDiffMargin</Name>
+      <IncludeOutputGroupsInVSIX>BuiltProjectOutputGroup;BuiltProjectOutputGroupDependencies;GetCopyToOutputDirectoryItems;SatelliteDllsProjectOutputGroup;PkgDefProjectOutputGroup</IncludeOutputGroupsInVSIX>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="source.extension.vsixmanifest">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
+</Project>

--- a/GitDiffMargin.Extension/Properties/AssemblyInfo.cs
+++ b/GitDiffMargin.Extension/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GitDiffMargin.Extension")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GitDiffMargin.Extension")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("e4701f35-8030-418e-8e8c-6ae72e229138")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GitDiffMargin.Extension/source.extension.vsixmanifest
+++ b/GitDiffMargin.Extension/source.extension.vsixmanifest
@@ -21,6 +21,8 @@
     </Prerequisites>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitDiffMargin" Path="|GitDiffMargin|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitDiffMargin.LegacyCommands" TargetVersion="[15.0,15.0.27131)" Path="|GitDiffMargin.LegacyCommands|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitDiffMargin.Commands" TargetVersion="[15.0.27428,16.0)" Path="|GitDiffMargin.Commands|" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitDiffMargin" Path="|GitDiffMargin;PkgdefProjectOutputGroup|" />
     </Assets>
 </PackageManifest>

--- a/GitDiffMargin.Extension/source.extension.vsixmanifest
+++ b/GitDiffMargin.Extension/source.extension.vsixmanifest
@@ -20,7 +20,7 @@
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
     <Assets>
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitDiffMargin" Path="|GitDiffMargin|" />
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitDiffMargin" Path="|GitDiffMargin;PkgdefProjectOutputGroup|" />
     </Assets>
 </PackageManifest>

--- a/GitDiffMargin.LegacyCommands/GitDiffMargin.LegacyCommands.csproj
+++ b/GitDiffMargin.LegacyCommands/GitDiffMargin.LegacyCommands.csproj
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{359BA5C3-6964-4FA4-941F-FB97E250C521}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>GitDiffMargin.LegacyCommands</RootNamespace>
+    <AssemblyName>GitDiffMargin.LegacyCommands</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="VSSDK.Editor.11" Version="11.0.4" />
+    <PackageReference Include="VSSDK.Shell.11" Version="11.0.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LegacyCommandHandlerTextViewCreationListener.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GitDiffMargin\GitDiffMargin.csproj">
+      <Project>{233b6f13-7687-4823-870b-a8f44b79d4f0}</Project>
+      <Name>GitDiffMargin</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/GitDiffMargin.LegacyCommands/LegacyCommandHandlerTextViewCreationListener.cs
+++ b/GitDiffMargin.LegacyCommands/LegacyCommandHandlerTextViewCreationListener.cs
@@ -1,4 +1,4 @@
-﻿namespace GitDiffMargin
+﻿namespace GitDiffMargin.LegacyCommands
 {
     using System.ComponentModel.Composition;
     using Microsoft.VisualStudio.Editor;
@@ -10,13 +10,13 @@
     [Export(typeof(IVsTextViewCreationListener))]
     [ContentType("text")]
     [TextViewRole(PredefinedTextViewRoles.Editable)]
-    internal class GitDiffMarginTextViewCreationListener : IVsTextViewCreationListener
+    internal class LegacyCommandHandlerTextViewCreationListener : IVsTextViewCreationListener
     {
         private readonly SVsServiceProvider _serviceProvider;
         private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
 
         [ImportingConstructor]
-        public GitDiffMarginTextViewCreationListener(SVsServiceProvider serviceProvider, IVsEditorAdaptersFactoryService editorAdaptersFactoryService)
+        public LegacyCommandHandlerTextViewCreationListener(SVsServiceProvider serviceProvider, IVsEditorAdaptersFactoryService editorAdaptersFactoryService)
         {
             _serviceProvider = serviceProvider;
             _editorAdaptersFactoryService = editorAdaptersFactoryService;

--- a/GitDiffMargin.LegacyCommands/Properties/AssemblyInfo.cs
+++ b/GitDiffMargin.LegacyCommands/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("GitDiffMargin.LegacyCommands")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("GitDiffMargin.LegacyCommands")]
+[assembly: AssemblyCopyright("Copyright ©  2018")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("359ba5c3-6964-4fa4-941f-fb97e250c521")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/GitDiffMargin.sln
+++ b/GitDiffMargin.sln
@@ -18,6 +18,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitDiffMargin.Commands", "GitDiffMargin.Commands\GitDiffMargin.Commands.csproj", "{AFEE8D6F-0358-4628-8CAC-D10668C95057}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitDiffMargin.LegacyCommands", "GitDiffMargin.LegacyCommands\GitDiffMargin.LegacyCommands.csproj", "{359BA5C3-6964-4FA4-941F-FB97E250C521}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +40,14 @@ Global
 		{B954F515-AC6F-40D4-8169-03985AC62B06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B954F515-AC6F-40D4-8169-03985AC62B06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{B954F515-AC6F-40D4-8169-03985AC62B06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFEE8D6F-0358-4628-8CAC-D10668C95057}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFEE8D6F-0358-4628-8CAC-D10668C95057}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFEE8D6F-0358-4628-8CAC-D10668C95057}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFEE8D6F-0358-4628-8CAC-D10668C95057}.Release|Any CPU.Build.0 = Release|Any CPU
+		{359BA5C3-6964-4FA4-941F-FB97E250C521}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{359BA5C3-6964-4FA4-941F-FB97E250C521}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{359BA5C3-6964-4FA4-941F-FB97E250C521}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{359BA5C3-6964-4FA4-941F-FB97E250C521}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GitDiffMargin.sln
+++ b/GitDiffMargin.sln
@@ -3,6 +3,8 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitDiffMargin.Extension", "GitDiffMargin.Extension\GitDiffMargin.Extension.csproj", "{E4701F35-8030-418E-8E8C-6AE72E229138}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitDiffMargin", "GitDiffMargin\GitDiffMargin.csproj", "{233B6F13-7687-4823-870B-A8F44B79D4F0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitDiffMargin.Unit.Tests", "GitDiffMargin.Unit.Tests\GitDiffMargin.Unit.Tests.csproj", "{B954F515-AC6F-40D4-8169-03985AC62B06}"
@@ -22,6 +24,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E4701F35-8030-418E-8E8C-6AE72E229138}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E4701F35-8030-418E-8E8C-6AE72E229138}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E4701F35-8030-418E-8E8C-6AE72E229138}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E4701F35-8030-418E-8E8C-6AE72E229138}.Release|Any CPU.Build.0 = Release|Any CPU
 		{233B6F13-7687-4823-870B-A8F44B79D4F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{233B6F13-7687-4823-870B-A8F44B79D4F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{233B6F13-7687-4823-870B-A8F44B79D4F0}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/GitDiffMargin/GitDiffMargin.csproj
+++ b/GitDiffMargin/GitDiffMargin.csproj
@@ -53,6 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Tvl.VisualStudio.Text.Utility.10" version="1.0.0" />
+    <PackageReference Include="MvvmLightLibs" Version="5.2.0.0" />
 
     <!-- This is a development-only dependency. -->
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.5.72" PrivateAssets="all" />
@@ -63,7 +64,6 @@
     -->
     <PackageReference Include="LibGit2Sharp" Version="0.24.1" PrivateAssets="all" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" ExcludeAssets="build" PrivateAssets="all" />
-    <PackageReference Include="MvvmLightLibs" Version="5.2.0.0" PrivateAssets="all" />
     <PackageReference Include="VSSDK.Editor.11" Version="11.0.4" PrivateAssets="all" />
     <PackageReference Include="VSSDK.Shell.11" Version="11.0.4" PrivateAssets="all" />
   </ItemGroup>
@@ -115,25 +115,21 @@
     <Content Include="$(NuGetPackageRoot)libgit2sharp.nativebinaries\1.0.205\runtimes\win7-x86\native\git2-dd2d538.dll">
       <Link>git2-dd2d538.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\GitDiffMargin-Preview.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\GitDiffMargin-Thumb.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="..\LICENSE.md">
       <Link>LICENSE.md</Link>
-      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\Git-Logo-2Color.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\Rollback.png" />
     <Content Include="Resources\ShowDifference.png" />
@@ -141,7 +137,6 @@
     <Content Include="Resources\CopyOldText.png" />
     <Content Include="Resources\Git-Icon-1788C.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\PreviousArrow.png" />
   </ItemGroup>

--- a/GitDiffMargin/GitDiffMargin.csproj
+++ b/GitDiffMargin/GitDiffMargin.csproj
@@ -17,19 +17,10 @@
     <FileAlignment>512</FileAlignment>
     <UseCodebase>true</UseCodebase>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <CreateVsixContainer>false</CreateVsixContainer>
     <Utf8Output>true</Utf8Output>
     <ExpressionBlendVersion>4.0.30816.0</ExpressionBlendVersion>
     <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup>
-    <!-- Common debugging support -->
-    <StartAction>Program</StartAction>
-    <StartProgram>$(DevEnvDir)\devenv.exe</StartProgram>
-    <StartArguments>/rootSuffix Exp</StartArguments>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != 'true'">
-    <!-- This property disables extension deployment for command line builds; required for AppVeyor -->
-    <DeployExtension>False</DeployExtension>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -62,7 +53,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.24.1" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" ExcludeAssets="build" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.5.72" PrivateAssets="all" />
     <PackageReference Include="MvvmLightLibs" Version="5.2.0.0" />
     <PackageReference Include="Tvl.VisualStudio.Text.Utility.10" version="1.0.0" />
@@ -118,28 +109,21 @@
     <Content Include="$(NuGetPackageRoot)libgit2sharp.nativebinaries\1.0.205\runtimes\win7-x86\native\git2-dd2d538.dll">
       <Link>git2-dd2d538.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\GitDiffMargin-Preview.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\GitDiffMargin-Thumb.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="..\LICENSE.md">
       <Link>LICENSE.md</Link>
-      <IncludeInVSIX>true</IncludeInVSIX>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="source.extension.vsixmanifest">
-      <SubType>Designer</SubType>
-    </None>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\Git-Logo-2Color.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\Rollback.png" />
     <Content Include="Resources\ShowDifference.png" />
@@ -147,7 +131,6 @@
     <Content Include="Resources\CopyOldText.png" />
     <Content Include="Resources\Git-Icon-1788C.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\PreviousArrow.png" />
   </ItemGroup>

--- a/GitDiffMargin/GitDiffMargin.csproj
+++ b/GitDiffMargin/GitDiffMargin.csproj
@@ -52,13 +52,20 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.24.1" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" ExcludeAssets="build" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.5.72" PrivateAssets="all" />
-    <PackageReference Include="MvvmLightLibs" Version="5.2.0.0" />
     <PackageReference Include="Tvl.VisualStudio.Text.Utility.10" version="1.0.0" />
-    <PackageReference Include="VSSDK.Editor.11" Version="11.0.4" />
-    <PackageReference Include="VSSDK.Shell.11" Version="11.0.4" />
+
+    <!-- This is a development-only dependency. -->
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="15.5.72" PrivateAssets="all" />
+
+    <!--
+      These are not development-only dependencies, but PrivateAssets is still used to avoid transitive dependencies when
+      GitDiffMargin.Commands references this project using a ProjectReference.
+    -->
+    <PackageReference Include="LibGit2Sharp" Version="0.24.1" PrivateAssets="all" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.205" ExcludeAssets="build" PrivateAssets="all" />
+    <PackageReference Include="MvvmLightLibs" Version="5.2.0.0" PrivateAssets="all" />
+    <PackageReference Include="VSSDK.Editor.11" Version="11.0.4" PrivateAssets="all" />
+    <PackageReference Include="VSSDK.Shell.11" Version="11.0.4" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Core\BackgroundParser.cs" />
@@ -66,7 +73,6 @@
     <Compile Include="GitDiffMarginCommand.cs" />
     <Compile Include="GitDiffMarginCommandHandler.cs" />
     <Compile Include="GitDiffMarginPackage.cs" />
-    <Compile Include="GitDiffMarginTextViewCreationListener.cs" />
     <Compile Include="Settings\DiffAdditionEditorFormatDefinition.cs" />
     <Compile Include="DiffMarginBase.cs" />
     <Compile Include="Settings\DiffModificationEditorFormatDefinition.cs" />
@@ -109,21 +115,25 @@
     <Content Include="$(NuGetPackageRoot)libgit2sharp.nativebinaries\1.0.205\runtimes\win7-x86\native\git2-dd2d538.dll">
       <Link>git2-dd2d538.dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\GitDiffMargin-Preview.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\GitDiffMargin-Thumb.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="..\LICENSE.md">
       <Link>LICENSE.md</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
   </ItemGroup>
   <ItemGroup>
     <Content Include="Resources\Git-Logo-2Color.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\Rollback.png" />
     <Content Include="Resources\ShowDifference.png" />
@@ -131,6 +141,7 @@
     <Content Include="Resources\CopyOldText.png" />
     <Content Include="Resources\Git-Icon-1788C.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <IncludeInVSIX>true</IncludeInVSIX>
     </Content>
     <Content Include="Resources\PreviousArrow.png" />
   </ItemGroup>

--- a/GitDiffMargin/GitDiffMarginCommand.cs
+++ b/GitDiffMargin/GitDiffMarginCommand.cs
@@ -2,7 +2,7 @@
 {
     using System.Runtime.InteropServices;
 
-    [Guid("691DB887-6D82-46A9-B0AF-407C7F0E39BE")]
+    [Guid(GitDiffMarginCommandHandler.GitDiffMarginCommandSet)]
     public enum GitDiffMarginCommand
     {
         PreviousChange = 0,

--- a/GitDiffMargin/GitDiffMarginCommandHandler.cs
+++ b/GitDiffMargin/GitDiffMarginCommandHandler.cs
@@ -15,6 +15,8 @@
 
     internal sealed class GitDiffMarginCommandHandler : TextViewCommandFilter
     {
+        internal const string GitDiffMarginCommandSet = "691DB887-6D82-46A9-B0AF-407C7F0E39BE";
+
         private readonly IVsEditorAdaptersFactoryService _editorAdaptersFactoryService;
         private readonly ITextView _textView;
 

--- a/GitDiffMargin/Properties/AssemblyInfo.cs
+++ b/GitDiffMargin/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Shell;
 
@@ -43,3 +44,6 @@ using Microsoft.VisualStudio.Shell;
     AssemblyName = "Tvl.VisualStudio.Text.Utility.10",
     Version = "1.0.0.0",
     CodeBase = "$PackageFolder$\\Tvl.VisualStudio.Text.Utility.10.dll")]
+
+[assembly: InternalsVisibleTo("GitDiffMargin.Commands")]
+[assembly: InternalsVisibleTo("GitDiffMargin.LegacyCommands")]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,5 +20,5 @@ build_script:
 - msbuild /p:configuration=Release /p:DeployExtension=false /p:ZipPackageCompressionLevel=normal /v:m
 
 artifacts:
-- path: '\GitDiffMargin\bin\Release\GitDiffMargin.vsix'
+- path: '\GitDiffMargin.Extension\bin\Release\GitDiffMargin.vsix'
   name: build


### PR DESCRIPTION
* Extract VSIX packaging to a separate project **GitDiffMargin.Extension**
* Add a project **GitDiffMargin.LegacyCommands**, which uses the current `TextViewCommandFilter` to implement commands for all versions prior to Visual Studio 2017 version 15.6
* Add a project **GitDiffMargin.Commands**, which uses the new `ICommandHandler` interface to implement commands in Visual Studio 2017 version 15.6 and later

This change should address the "Gold Bar" notification saying Git Diff Margin was responsible for editor slowness. When using chained command filters, the slowness detection doesn't know how to assign blame to a specific item in the chain, so Git Diff Margin can be blamed for cases where it's doing nothing but passing the command along the chain. The new code uses a declarative approach to handle specific commands, and is no longer part of the handling process for unrelated editor commands.

The code is based loosely on the [Visual Studio 2017 backwards compatible editor command](https://github.com/Microsoft/VSSDK-Extensibility-Samples/tree/master/Backwards_Compatible_Editor_Command/) sample, but continues to use the `IOleCommandTarget` implementation for both old and new command handling approaches.

@olegtk I'm not sure y'all meant to make it *this difficult* to work with the new API, but if we have to multiply the number of assemblies by 4 every time we want to support a new editor feature this is going to get out of hand really fast. Please make sure that future APIs are designed from the perspective of users who are supporting earlier clients by default, with clients only supporting new APIs being the outlier not the standard.