### PR TITLE
Use ProvideBindingPath instead of ProvideCodeBase

### DIFF
--- a/GitDiffMargin.Extension/GitDiffMargin.Extension.csproj
+++ b/GitDiffMargin.Extension/GitDiffMargin.Extension.csproj
@@ -13,7 +13,7 @@
     <AssemblyName>GitDiffMargin.Extension</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <GeneratePkgDefFile>true</GeneratePkgDefFile>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
     <TargetVsixContainerName>GitDiffMargin.vsix</TargetVsixContainerName>

--- a/GitDiffMargin.Extension/Properties/AssemblyInfo.cs
+++ b/GitDiffMargin.Extension/Properties/AssemblyInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio.Shell;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -21,8 +21,6 @@ using Microsoft.VisualStudio.Shell;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e4701f35-8030-418e-8e8c-6ae72e229138")]
-
-[assembly: ProvideCodeBase(CodeBase = "$PackageFolder$\\GitDiffMargin.Commands.dll")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/GitDiffMargin.Extension/source.extension.vsixmanifest
+++ b/GitDiffMargin.Extension/source.extension.vsixmanifest
@@ -24,6 +24,5 @@
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitDiffMargin.LegacyCommands" TargetVersion="[15.0,15.0.27131)" Path="|GitDiffMargin.LegacyCommands|" />
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="GitDiffMargin.Commands" TargetVersion="[15.0.27428,16.0)" Path="|GitDiffMargin.Commands|" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="GitDiffMargin" Path="|GitDiffMargin;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
     </Assets>
 </PackageManifest>

--- a/GitDiffMargin.LegacyCommands/GitDiffMargin.LegacyCommands.csproj
+++ b/GitDiffMargin.LegacyCommands/GitDiffMargin.LegacyCommands.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="VSSDK.Editor.11" Version="11.0.4" />
-    <PackageReference Include="VSSDK.Shell.11" Version="11.0.4" PrivateAssets="all" />
+    <PackageReference Include="VSSDK.Shell.11" Version="11.0.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="LegacyCommandHandlerTextViewCreationListener.cs" />

--- a/GitDiffMargin/GitDiffMarginPackage.cs
+++ b/GitDiffMargin/GitDiffMarginPackage.cs
@@ -9,6 +9,8 @@
 
     [ProvideMenuResource("Menus.ctmenu", 1)]
 
+    // https://github.com/laurentkempe/GitDiffMargin/issues/165
+    [ProvideBindingPath]
     public class GitDiffMarginPackage : Package
     {
     }

--- a/GitDiffMargin/Properties/AssemblyInfo.cs
+++ b/GitDiffMargin/Properties/AssemblyInfo.cs
@@ -2,7 +2,6 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Microsoft.VisualStudio.Shell;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -35,15 +34,6 @@ using Microsoft.VisualStudio.Shell;
 [assembly: AssemblyVersion("3.8.0.0")]
 [assembly: AssemblyFileVersion("3.8.0.0")]
 [assembly: AssemblyInformationalVersion("3.8.0.0")]
-
-[assembly: ProvideCodeBase(
-    AssemblyName = "Tvl.VisualStudio.Shell.Utility.10",
-    Version = "1.0.0.0",
-    CodeBase = "$PackageFolder$\\Tvl.VisualStudio.Shell.Utility.10.dll")]
-[assembly: ProvideCodeBase(
-    AssemblyName = "Tvl.VisualStudio.Text.Utility.10",
-    Version = "1.0.0.0",
-    CodeBase = "$PackageFolder$\\Tvl.VisualStudio.Text.Utility.10.dll")]
 
 [assembly: InternalsVisibleTo("GitDiffMargin.Commands")]
 [assembly: InternalsVisibleTo("GitDiffMargin.LegacyCommands")]


### PR DESCRIPTION
`[ProvideCodeBase]` does not appear to work when modern command handling is used.

Fixes #165 