### PR TITLE
Avoid crashing if GitDiffMarginCommandHandler is not in the property bag

### DIFF
--- a/GitDiffMargin/ViewModel/EditorDiffViewModel.cs
+++ b/GitDiffMargin/ViewModel/EditorDiffViewModel.cs
@@ -169,15 +169,16 @@ namespace GitDiffMargin.ViewModel
                     IVsUIShell4 uiShell = Package.GetGlobalService(typeof(SVsUIShell)) as IVsUIShell4;
                     if (uiShell != null)
                     {
-                        IOleCommandTarget commandTarget = MarginCore.TextView.Properties.GetProperty<GitDiffMarginCommandHandler>(typeof(GitDiffMarginCommandHandler));
+                        if (MarginCore.TextView.Properties.TryGetProperty<GitDiffMarginCommandHandler>(typeof(GitDiffMarginCommandHandler), out var commandTarget))
+                        {
+                            IVsToolbarTrayHost toolbarTrayHost;
+                            ErrorHandler.ThrowOnFailure(uiShell.CreateToolbarTray(commandTarget, out toolbarTrayHost));
 
-                        IVsToolbarTrayHost toolbarTrayHost;
-                        ErrorHandler.ThrowOnFailure(uiShell.CreateToolbarTray(commandTarget, out toolbarTrayHost));
+                            Guid toolBarGuid = typeof(GitDiffMarginCommand).GUID;
+                            ErrorHandler.ThrowOnFailure(toolbarTrayHost.AddToolbar(ref toolBarGuid, (int)GitDiffMarginCommand.GitDiffToolbar));
 
-                        Guid toolBarGuid = typeof(GitDiffMarginCommand).GUID;
-                        ErrorHandler.ThrowOnFailure(toolbarTrayHost.AddToolbar(ref toolBarGuid, (int)GitDiffMarginCommand.GitDiffToolbar));
-
-                        _toolbarTrayHost = toolbarTrayHost;
+                            _toolbarTrayHost = toolbarTrayHost;
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
I've had several recent crashes of the following form:

```
Application: devenv.exe
Framework Version: v4.0.30319
Description: The process was terminated due to an unhandled exception.
Exception Info: System.Collections.Generic.KeyNotFoundException
   at Microsoft.VisualStudio.Utilities.PropertyCollection.GetProperty(System.Object)
   at GitDiffMargin.ViewModel.EditorDiffViewModel.set_ShowPopup(Boolean)
   at GitDiffMargin.ViewModel.EditorDiffViewModel.ShowPopUp(GitDiffMargin.ViewModel.EditorDiffMarginViewModel)
```

I haven't figured out why this is occurring, but this pull request avoids the crash by instead not showing the tool bar for these cases. Hopefully the added stability will allow users to find some better repro cases that we can then fix.