### PR TITLE
Fix #240 Leak EventHandler

### DIFF
--- a/GitDiffMargin/EditorDiffMargin.cs
+++ b/GitDiffMargin/EditorDiffMargin.cs
@@ -31,6 +31,13 @@ namespace GitDiffMargin
             UserControl = new EditorDiffMarginControl {DataContext = ViewModel, Width = MarginWidth};
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            ViewModel.Cleanup();
+
+            base.Dispose(disposing);
+        }
+
         private void UpdateDiffDimensions(DiffViewModel diffViewModel, HunkRangeInfo hunkRangeInfo)
         {
             if (TextView.IsClosed)

--- a/GitDiffMargin/ScrollDiffMargin.cs
+++ b/GitDiffMargin/ScrollDiffMargin.cs
@@ -31,6 +31,13 @@ namespace GitDiffMargin
             UserControl = new ScrollDiffMarginControl { DataContext = ViewModel, Width = MarginWidth, MaxWidth = MarginWidth, MinWidth = MarginWidth};
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            ViewModel.Cleanup();
+
+            base.Dispose(disposing);
+        }
+
         private void UpdateDiffDimensions(DiffViewModel diffViewModel, HunkRangeInfo hunkRangeInfo)
         {
             if (TextView.IsClosed)

--- a/GitDiffMargin/ViewModel/DiffMarginViewModelBase.cs
+++ b/GitDiffMargin/ViewModel/DiffMarginViewModelBase.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using GalaSoft.MvvmLight;
@@ -36,6 +35,10 @@ namespace GitDiffMargin.ViewModel
 
         protected virtual void HandleHunksChanged(object sender, HunksChangedEventArgs e)
         {
+            foreach (var diffViewModel in DiffViewModels)
+            {
+                diffViewModel.Cleanup();
+            }
             DiffViewModels.Clear();
 
             foreach (var diffViewModel in e.Hunks.Select(CreateDiffViewModel))

--- a/GitDiffMargin/ViewModel/DiffViewModel.cs
+++ b/GitDiffMargin/ViewModel/DiffViewModel.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Windows;
-using System.Windows.Media;         
+using System.Windows.Media;
 using GalaSoft.MvvmLight;
 using GitDiffMargin.Core;
 using GitDiffMargin.Git;
@@ -102,6 +102,13 @@ namespace GitDiffMargin.ViewModel
             }
 
             return lineNumber >= diffStartLine && lineNumber <= diffEndLine;
+        }
+
+        public override void Cleanup()
+        {
+            MarginCore.BrushesChanged -= HandleBrushesChanged;
+
+            base.Cleanup();
         }
 
         private void HandleBrushesChanged(object sender, EventArgs e)


### PR DESCRIPTION
Ensuring to unregister from BrushesChanged event when either a Hunk changed or when either the EditorDiffMargin or ScrollDiffMargin are disposed.