### PR TITLE
Load the correct architecture binaries when needed

### DIFF
--- a/GitDiffMargin/Git/GitCommands.cs
+++ b/GitDiffMargin/Git/GitCommands.cs
@@ -39,7 +39,7 @@ namespace GitDiffMargin.Git
             try
             {
                 var currentFolder = Path.GetDirectoryName(typeof(GitCommands).Assembly.Location);
-                var subFolder = "x86";
+                var subFolder = Environment.Is64BitProcess ? "x64" : "x86";
                 LoadLibrary(Path.Combine(currentFolder, subFolder, $"git2-{VersionAccessor.Instance.LibGit2CommitSha}.dll"));
             }
             catch

--- a/GitDiffMargin/GitDiffMargin.csproj
+++ b/GitDiffMargin/GitDiffMargin.csproj
@@ -117,6 +117,10 @@
     <Compile Include="Core\WeakReference.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\win-x64\native\$(libgit2_filename).dll">
+      <Link>x64\$(libgit2_filename).dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="$(PkgLibGit2Sharp_NativeBinaries)\runtimes\win-x86\native\$(libgit2_filename).dll">
       <Link>x86\$(libgit2_filename).dll</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
Now that [Visual Studio 2022](https://devblogs.microsoft.com/visualstudio/visual-studio-2022/) announcement is public.

Follow-up to #379

More changes will be necessary but this is a first step.