### PR TITLE
Fix image assembly load by providing the full name

### DIFF
--- a/GitDiffMargin.Shim/GitDiffMargin.Shim.csproj
+++ b/GitDiffMargin.Shim/GitDiffMargin.Shim.csproj
@@ -58,4 +58,19 @@
     <ProjectReference Update="@(ProjectReference)" Name="%(Filename)" />
   </ItemGroup>
 
+  <!--
+    Icons.imagemanifest contains a reference to the strong name of GitDiffMargin.Shim.dll. This target validates the
+    reference matches the values applied to the assembly by NerdBank.GitVersioning during the build.
+  -->
+  <Target Name="ValidateImageManifestVersion"
+          BeforeTargets="CopyFilesToOutputDirectory">
+
+    <PropertyGroup>
+      <_ImageManifestText>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)Icons.imagemanifest'))</_ImageManifestText>
+      <_ExpectedImageManifestResources>/$(AssemblyName);v$(AssemblyVersion);72dfb55bb9fc8a25;</_ExpectedImageManifestResources>
+    </PropertyGroup>
+
+    <Error Condition="!$(_ImageManifestText.Contains('$(_ExpectedImageManifestResources)'))"
+           Text="Expected 'Icons.imagemanifest' to contain '$(_ExpectedImageManifestResources)'" />
+  </Target>
 </Project>

--- a/GitDiffMargin.Shim/Icons.imagemanifest
+++ b/GitDiffMargin.Shim/Icons.imagemanifest
@@ -3,7 +3,7 @@
 <!-- Version: 14.0.50929.2 -->
 <ImageManifest xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.microsoft.com/VisualStudio/ImageManifestSchema/2014">
   <Symbols>
-    <String Name="Resources" Value="/GitDiffMargin.Shim;component/resources/icons" />
+    <String Name="Resources" Value="/GitDiffMargin.Shim;v3.11.0.0;72dfb55bb9fc8a25;component/resources/icons" />
     <Guid Name="guidGitDiffMarginIcons" Value="{3e6659f9-943a-4ba2-89d6-a7974e8b4e2f}" />
     <ID Name="GitDiffMarginShowDiff" Value="1" />
     <ID Name="GitDiffMarginRollbackChange" Value="2" />


### PR DESCRIPTION
This approach works, but will require manual updates to the version number whenever **version.json** changes (e.g. 30ea1d3).

Fixes #383