### PR TITLE
Update Microsoft.VSSDK.BuildTools to support building in dev17

### DIFF
--- a/GitDiffMargin.Extension/GitDiffMargin.Extension.csproj
+++ b/GitDiffMargin.Extension/GitDiffMargin.Extension.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.6.56" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
     <PackageReference Include="StreamJsonRpc" Version="1.3.23" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.63-dev17-g3f11f5ab" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.2155-preview2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GitDiffMargin.Shim/GitDiffMargin.Shim.csproj
+++ b/GitDiffMargin.Shim/GitDiffMargin.Shim.csproj
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <PackageReference Include="VSSDK.Shell.11" Version="11.0.4" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.63-dev17-g3f11f5ab" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.2155-preview2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GitDiffMargin/GitDiffMargin.15.csproj
+++ b/GitDiffMargin/GitDiffMargin.15.csproj
@@ -39,7 +39,7 @@
   <ItemGroup>
     <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" />
     <!-- This is a development-only dependency. -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.63-dev17-g3f11f5ab" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="15.0.26201" PrivateAssets="all" />
     <!--
       These are not development-only dependencies, but PrivateAssets is still used to avoid transitive dependencies when

--- a/GitDiffMargin/GitDiffMargin.16.csproj
+++ b/GitDiffMargin/GitDiffMargin.16.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" />
     <!-- This is a development-only dependency. -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.63-dev17-g3f11f5ab" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="15.6.27413" PrivateAssets="all" />
     <!--
       These are not development-only dependencies, but PrivateAssets is still used to avoid transitive dependencies when

--- a/GitDiffMargin/GitDiffMargin.17.csproj
+++ b/GitDiffMargin/GitDiffMargin.17.csproj
@@ -38,7 +38,7 @@
   <ItemGroup>
     <PackageReference Include="MvvmLightLibs" Version="5.4.1.1" />
     <!-- This is a development-only dependency. -->
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.63-dev17-g3f11f5ab" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.2155-preview2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="17.0.0-previews-1-31318-291" PrivateAssets="all" />
     <!--
       These are not development-only dependencies, but PrivateAssets is still used to avoid transitive dependencies when


### PR DESCRIPTION
Following this change, the project will build in _both_ Visual Studio 2019 and Visual Studio 2022.